### PR TITLE
Fixed the Ds 18 example. Added three methods to the Display class

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -247,3 +247,49 @@ void Display::write(byte symbol, uint8_t position)
   ic.End();
 }
 
+/**
+ * @brief 
+ * 
+ * @param number 
+ * @param position 
+ */
+void Display::writeOne(uint8_t number, uint8_t position)
+{
+  ic.SendByte(numbers[number]);  
+  ic.SendByte(0x10 << position);
+  ic.End();
+}
+
+/**
+ * @brief 
+ * 
+ * @param number 
+ */
+void Display::writeNumber(uint16_t number)
+{
+  if (number < 10000)
+  {
+    uint8_t temp1 = (uint8_t)(number / 1000);
+    uint8_t position = 3;
+    writeOne(temp1, position--); // thousands
+    uint8_t temp2 = ( (uint8_t)((number - (temp1 * 1000)) / 100) );
+    writeOne(temp2, position--); // hundreds
+    uint8_t temp3 = ( (uint8_t)((number - (temp1 * 1000) - (temp2 * 100)) / 10) );
+    writeOne(temp3, position--); // dozens
+    uint8_t temp4 = ( (uint8_t)((number - (temp1 * 1000) - (temp2 * 100) - (temp3 * 10))) );
+    writeOne(temp4, position); // units
+  }
+}
+
+/**
+ * @brief 
+ * 
+ * @param position 
+ */
+void Display::writeDot(uint8_t position)
+{
+  ic.SendByte(DISPLAY_DOT);  
+  ic.SendByte(0x10 << position);
+  ic.End();
+}
+

--- a/display.h
+++ b/display.h
@@ -95,6 +95,9 @@ class Display
         static void write(byte symbol, uint8_t position);
         static void writeInteger(const int16_t number, bool left_zeros=false, uint8_t offset=0);
         static void clear();
+        static void writeOne(uint8_t number, uint8_t position);
+        static void writeNumber(uint16_t number);
+        static void writeDot(uint8_t position);
 };
 
 #endif

--- a/examples/Ds18/Ds18.ino
+++ b/examples/Ds18/Ds18.ino
@@ -1,6 +1,9 @@
 #include <hw262.h>
 
-int temp;
+float temp = 0;
+uint64_t currentTime = 0;
+uint64_t intervalTime = 0x800; // about 2 seconds
+
 
 void setup() {
     Serial.begin(9600);
@@ -13,4 +16,16 @@ void loop()
 {
   temp = HW262.ds18.getTemp();  
   // for(uint32_t i=0; i<5000; i++) HW262.display.writeNumber(temp);
+  while( ! temp );
+  
+  noInterrupts();
+  while(currentTime < intervalTime)
+  {
+    HW262.display.writeNumber( (int16_t)temp*100 );
+    HW262.display.writeDot(2);
+    currentTime++;
+  }
+  currentTime = 0;
+  interrupts();
+  temp = 0;
 }


### PR DESCRIPTION
I fixed the Ds 18 example, disabled interrupts for the time of displaying numbers on the display and added temperature expectation from the sensor. Added three methods to the Display class