### PR TITLE
WiP: Add IR communication support and example for HW262

### DIFF
--- a/examples/IRReceiver/IRReceiver.ino
+++ b/examples/IRReceiver/IRReceiver.ino
@@ -1,0 +1,29 @@
+#include <hw262.h>
+
+uint16_t number = 0;
+uint64_t currentTime;
+uint64_t elapsedTime = 0;
+uint64_t intervalTime = 100;
+irdata_t data;
+
+void setup() {
+  HW262.begin();
+  HW262.display.clear();
+  memset(&data, 0x00, sizeof(data));
+}
+
+void loop() {
+  currentTime = millis();
+
+  int error = HW262.ir.getCommand(&data);
+
+  if (!error)
+    Serial.println((long unsigned int)data.raw_data);
+
+  while (elapsedTime < intervalTime) {
+    elapsedTime = millis() - currentTime;
+    HW262.display.writeNumber(data.command);
+  }
+
+  elapsedTime = 0;
+}

--- a/hw262.cpp
+++ b/hw262.cpp
@@ -1,15 +1,12 @@
 
 #include "hw262.h"
 
-
 Ds18 Hw262::ds18;
 Lm35 Hw262::lm35(DEFAULT_PRECISION);
 Display Hw262::display;
 
-
-void Hw262::begin(uint8_t sensorPrecision, uint32_t baudRate)
-{
-  Serial.begin(SERIAL_BAUD_RATE);
+void Hw262::begin(uint8_t sensorPrecision, uint32_t baudRate) {
+  Serial.begin(baudRate);
   delay(100);
   Led();
   resetAllLeds();
@@ -17,28 +14,20 @@ void Hw262::begin(uint8_t sensorPrecision, uint32_t baudRate)
   Switches();
   lm35.setPrecision(sensorPrecision);
   ds18.begin();
-  
+  ir.begin(false);
 }
-
 
 /**
  * @brief Read ADC channel at pin A5
- * @return uint16_t 
+ * @return uint16_t
  */
-uint16_t Hw262::readA5()
-{
-    return analogRead(A5);
+uint16_t Hw262::readA5() { return analogRead(A5); }
+
+uint16_t Hw262::readVoltageA5() {
+  return (SOURCE_VOLTAGE / MAX_VALUE_ADC) * readA5();
 }
 
-
-uint16_t Hw262::readVoltageA5()
-{
-    return(SOURCE_VOLTAGE/MAX_VALUE_ADC)*readA5();
+void Hw262::resetAllLeds() {
+  for (uint8_t pinLed = D4_PIN; pinLed <= D1_PIN; pinLed++)
+    ledOff(pinLed);
 }
-
-
-void Hw262::resetAllLeds()
-{
-  for(uint8_t pinLed=D4_PIN; pinLed<=D1_PIN; pinLed++) ledOff(pinLed);
-}
-

--- a/hw262.h
+++ b/hw262.h
@@ -9,6 +9,7 @@
 #include "display.h"
 #include "ds18.h"
 #include "lm35.h"
+#include "ir.h"
 #include "constants.h"
 #include "pins.h"
 
@@ -26,6 +27,7 @@ class Hw262 :   public Led,
         static Lm35 lm35;
         static Ds18 ds18;
         static Display display;
+        static IR ir;
         static void resetAllLeds();
 };
 

--- a/ir.cpp
+++ b/ir.cpp
@@ -1,0 +1,24 @@
+#include "ir.h"
+#include <IRremote.hpp>
+
+void IR::begin(bool feedback_led=false) {
+  IrReceiver.begin(IR_RECEIVE_PIN, feedback_led);
+  Serial.println("IR begin");
+}
+
+int32_t IR::getCommand(irdata_t *irdata) {
+  if (!irdata) {
+    return -1;
+  }
+
+  bool decoded = IrReceiver.decode();
+  if (decoded) {
+    IrReceiver.resume();
+    irdata->address = IrReceiver.decodedIRData.address;
+    irdata->command = IrReceiver.decodedIRData.command;
+    irdata->raw_data = IrReceiver.decodedIRData.decodedRawData;
+    return 0;
+  }
+
+  return -1;
+}

--- a/ir.h
+++ b/ir.h
@@ -1,0 +1,39 @@
+#ifndef IR_H
+#define IR_H
+
+#include <Arduino.h>
+#include "pins.h"
+
+
+#define IR_RECEIVE_PIN 2
+
+typedef struct irdata_t {
+  uint16_t address;
+  uint16_t command;
+  uint64_t raw_data;
+} irdata_t;
+
+/**
+ * @class IR
+ * @brief A class to handle IR (Infrared) communication.
+ */
+class IR {
+public:
+  /**
+   * @brief Initializes the IR communication.
+   *
+   * @param feedback_led A boolean indicating whether to use a feedback LED.
+   */
+  static void begin(bool feedback_led);
+
+  /**
+   * @brief Retrieves the IR command.
+   *
+   * @param irdata A pointer to an irdata_t structure to store the received IR
+   * data.
+   * @return int32_t The command received via IR.
+   */
+  static int32_t getCommand(irdata_t *irdata);
+};
+
+#endif // IR_H

--- a/library.properties
+++ b/library.properties
@@ -8,5 +8,5 @@ category=Other
 url=https://github.com/HighASG936/hw262
 architectures=avr
 includes=hw262.h
-depends=OneWireHub, DallasTemperature, Mc74hc595a
+depends=OneWireHub, DallasTemperature, Mc74hc595a, IRremote
 


### PR DESCRIPTION
I saw that there is missing support for IR receiver. I did not have TSOP1838, but TSOP2236. I managed to attach it to the hat using wires. The methods I provided (begin & getCommand) should be sufficient for usage with Arduino. The code relies on well known library: https://github.com/Arduino-IRremote

![6003378821493017181](https://github.com/user-attachments/assets/25649c29-1425-48e3-8009-987305edd402)

Let me know what you think 😉 
